### PR TITLE
Mark as deprecated and point users to the Vulnerability Advisor tester instead

### DIFF
--- a/Language_en.properties
+++ b/Language_en.properties
@@ -1,8 +1,8 @@
 # NLS_MESSAGEFORMAT_NONE
 # NLS_ENCODING=UTF-8
-ExtName=IBM Vulnerability Adviser
-ExtDesc=Run compliance and vulnerability checks against a pushed docker container image.
-ExtMessage=To leverage this extension, it must be set up with input from an <b>IBM Container service</b> build stage. A compliance and vulnerability check will be run, and the results displayed.  If any issues are found, this stage will fail.<br><br>For information and a quick-start guide view our <a href="https://www.ng.bluemix.net/docs/containers/container_single_pipeline_ov.html#container_pipeline_vulnerability" target="_blank">documentation</a>.
+ExtName=DEPRECATED - IBM Vulnerability Adviser
+ExtDesc=DEPRECATED - Use the "Vulnerability Advisor" test type instead. Run compliance and vulnerability checks against a pushed docker container image.
+ExtMessage=DEPRECATED - Use the "Vulnerability Advisor" test type instead. To leverage this extension, it must be set up with input from an <b>IBM Container service</b> build stage. A compliance and vulnerability check will be run, and the results displayed.  If any issues are found, this stage will fail.<br><br>For information and a quick-start guide view our <a href="https://www.ng.bluemix.net/docs/containers/container_single_pipeline_ov.html#container_pipeline_vulnerability" target="_blank">documentation</a>.
 
 WAIT_TIME_KEY=Minutes to wait for analysis to complete (0 - 59)
 WAIT_TIME_DESC=Specify a maximum amount of time in minutes to block the pipeline from running other jobs, which allows the analysis to complete. After the job completes, if the analysis has completed, the results will be displayed in the test log. If the analysis did not complete before the time specified, you can resubmit the job to have it continue waiting for the analysis to finish.  This value must be set to a whole number between 0 and 59.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# compliance_crawler
+# DEPRECATED - compliance_crawler
 (proof of concept) Experimental extension enabling compliance and vulnerability checking against container images. Find potential issues at build time and prevent them from going live. 
 
 Calls made herein are not final and may change or be removed at any time with no notice.

--- a/_init.sh
+++ b/_init.sh
@@ -69,6 +69,11 @@ popd >/dev/null
 source ${EXT_DIR}/utilities/ice_utils.sh
 source ${EXT_DIR}/utilities/logging_utils.sh
 
+#################################
+# Show deprecated message       #
+#################################
+log_and_echo "$ERROR" "ATTENTION: This job type has been DEPRECATED. Please use the 'Vulnerability Advisor' test type instead."
+
 ##############################
 # Identify the Image to use  #
 ##############################


### PR DESCRIPTION
In the face of native pipeline jobs with this functionality I have been asked to deprecate this extension and mark it to users as so in the UI.